### PR TITLE
Remove use_2to3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,5 @@ setup(
     keywords = 'pelican blog static thumbnail generation',
     description = ('A thumbnail generator for Pelican that operates by looking'
             ' at the filename of missing files to determine thumb format.'),
-    use_2to3 = True,
     long_description = long_description
 )


### PR DESCRIPTION
use_2to3 flag has been removed in [setuptools 58](https://setuptools.readthedocs.io/en/latest/history.html#v58-0-0). o the package cannot be installed using pip. See #8 . This simple patch removed the use of the flag.